### PR TITLE
Store metadata

### DIFF
--- a/donutdb_test.go
+++ b/donutdb_test.go
@@ -509,7 +509,7 @@ func TestReadWriteCases(t *testing.T) {
 					size:   1,
 				},
 				{
-					offset: sectorSize,
+					offset: defaultSectorSize,
 					size:   10,
 				},
 			},
@@ -524,8 +524,8 @@ func TestReadWriteCases(t *testing.T) {
 					size:   1,
 				},
 				{
-					offset: sectorSize * 2,
-					size:   sectorSize,
+					offset: defaultSectorSize * 2,
+					size:   defaultSectorSize,
 				},
 			},
 		},

--- a/dynamo_sector.go
+++ b/dynamo_sector.go
@@ -126,7 +126,7 @@ func (f *file) getSectorRange(firstSector, lastSector int64) ([]sector, error) {
 
 	query := "hash_key = :hk AND range_key BETWEEN :first_sector AND :last_sector"
 	var sectors []sector
-	prevSectorOffset := firstSector - sectorSize
+	prevSectorOffset := firstSector - defaultSectorSize
 
 	for {
 		startSectorStr := strconv.FormatInt(startSector, 10)
@@ -163,8 +163,8 @@ func (f *file) getSectorRange(firstSector, lastSector int64) ([]sector, error) {
 				return nil, fmt.Errorf("range_key does not parse to an int: %s %w", *item[rKey].N, err)
 			}
 
-			if sectorOffset != prevSectorOffset+sectorSize {
-				return nil, fmt.Errorf("Unexpected sector offset for range %d-%d, prev=%d got=%d expected=%d", firstSector, lastSector, prevSectorOffset, sectorOffset, prevSectorOffset+sectorSize)
+			if sectorOffset != prevSectorOffset+defaultSectorSize {
+				return nil, fmt.Errorf("Unexpected sector offset for range %d-%d, prev=%d got=%d expected=%d", firstSector, lastSector, prevSectorOffset, sectorOffset, prevSectorOffset+defaultSectorSize)
 			}
 
 			sectorData := item["bytes"].B

--- a/dynamo_sector.go
+++ b/dynamo_sector.go
@@ -19,7 +19,7 @@ func (f *file) getSector(sectorOffset int64) (*sector, error) {
 		Limit:                  aws.Int64(1),
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			":hk": {
-				S: &f.name,
+				S: &f.dataRowKey,
 			},
 			":rk": {
 				N: &rangeKeyStr,
@@ -56,7 +56,7 @@ func (f *file) writeSector(s *sector) error {
 		TableName: &f.vfs.table,
 		Item: map[string]*dynamodb.AttributeValue{
 			hKey: {
-				S: &f.name,
+				S: &f.dataRowKey,
 			},
 			rKey: {
 				N: &rangeKeyStr,
@@ -79,7 +79,7 @@ func (f *file) getLastSector() (*sector, error) {
 		Limit:                  aws.Int64(1),
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			":hk": {
-				S: &f.name,
+				S: &f.dataRowKey,
 			},
 		},
 	})
@@ -139,7 +139,7 @@ func (f *file) getSectorRange(firstSector, lastSector int64) ([]sector, error) {
 			Limit:                  aws.Int64(1000),
 			ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 				":hk": {
-					S: &f.name,
+					S: &f.dataRowKey,
 				},
 				":first_sector": {
 					N: &startSectorStr,

--- a/global_lock_strategy.go
+++ b/global_lock_strategy.go
@@ -30,8 +30,8 @@ type globalLockManager struct {
 	err error
 }
 
-func newGlobalLockManger(db *dynamodb.DynamoDB, table, name, owner string) *globalLockManager {
-	lockName := "lock-global-v1-" + name
+func newGlobalLockManger(db *dynamodb.DynamoDB, table, name, randID, owner string) *globalLockManager {
+	lockName := fileLockPrefix + randID + "-" + name
 	lm := &globalLockManager{
 		db:       db,
 		table:    table,

--- a/global_lock_strategy.go
+++ b/global_lock_strategy.go
@@ -30,8 +30,7 @@ type globalLockManager struct {
 	err error
 }
 
-func newGlobalLockManger(db *dynamodb.DynamoDB, table, name, randID, owner string) *globalLockManager {
-	lockName := fileLockPrefix + randID + "-" + name
+func newGlobalLockManger(db *dynamodb.DynamoDB, table, lockName, owner string) *globalLockManager {
 	lm := &globalLockManager{
 		db:       db,
 		table:    table,

--- a/sector_scanner.go
+++ b/sector_scanner.go
@@ -47,7 +47,7 @@ func (i *sectorIterator) Next() bool {
 	*i.sectorPtr = i.cachedSectors[0]
 	i.cachedSectors = i.cachedSectors[1:]
 
-	i.offset = i.sectorPtr.offset + sectorSize
+	i.offset = i.sectorPtr.offset + defaultSectorSize
 
 	return true
 }

--- a/sector_writer.go
+++ b/sector_writer.go
@@ -63,7 +63,7 @@ func (w *sectorWriter) flush() error {
 			PutRequest: &dynamodb.PutRequest{
 				Item: map[string]*dynamodb.AttributeValue{
 					hKey: {
-						S: &w.f.name,
+						S: &w.f.dataRowKey,
 					},
 					rKey: {
 						N: &rangeKeyStr,
@@ -83,7 +83,7 @@ func (w *sectorWriter) flush() error {
 			DeleteRequest: &dynamodb.DeleteRequest{
 				Key: map[string]*dynamodb.AttributeValue{
 					hKey: {
-						S: &w.f.name,
+						S: &w.f.dataRowKey,
 					},
 					rKey: {
 						N: &rangeKeyStr,


### PR DESCRIPTION
Add back separate row for file metadata. 

This currently serves two purposes:

It allows us to add a level of indirection between the filename and
the file data. This makes things like `rm file` safer, as we can now
delete the reference to the file and then we don't need to worry too
much about errors occurring while deleting the data (we still care
about deleting the file data so we don't leak rows).

It also allows us to track the sector size on a per file basis. I'm
not sure yet what the optimal sector size is. I'd like to be able to
experiment with different sizes without making old files inaccessible.
It is not currently possible to change the sector size of an existing
file.
