### PR TITLE
Make FullPathname always prefix paths with '/'

### DIFF
--- a/donutdb.go
+++ b/donutdb.go
@@ -258,7 +258,8 @@ func (v *vfs) Access(name string, flag sqlite3vfs.AccessFlag) (bool, error) {
 }
 
 func (vfs *vfs) FullPathname(name string) string {
-	return filepath.Clean(name)
+	name = filepath.Clean(string(filepath.Separator) + name)
+	return name
 }
 
 type file struct {

--- a/donutdb_test.go
+++ b/donutdb_test.go
@@ -588,6 +588,39 @@ func TestReadWriteCases(t *testing.T) {
 	}
 }
 
+func TestFullPathname(t *testing.T) {
+	checks := []struct {
+		in     string
+		expect string
+	}{
+		{
+			in:     "rancidity-embalmers.db",
+			expect: "/rancidity-embalmers.db",
+		},
+		{
+			in:     "/rancidity-embalmers.db",
+			expect: "/rancidity-embalmers.db",
+		},
+		{
+			in:     "//rancidity-embalmers.db",
+			expect: "/rancidity-embalmers.db",
+		},
+		{
+			in:     "//critical///swapping.db",
+			expect: "/critical/swapping.db",
+		},
+	}
+
+	v := vfs{}
+
+	for _, check := range checks {
+		got := v.FullPathname(check.in)
+		if got != check.expect {
+			t.Fatalf("Check fullpath: in=%s, got=%s expect=%s", check.in, got, check.expect)
+		}
+	}
+}
+
 type FooRow struct {
 	ID    string
 	Title string


### PR DESCRIPTION
This mainly makes it easier to work with the loadable module from the
sqlite3 cli and the sqlite URI syntax. The URI syntax is always an
absolute path so will always begin with the path separator.

Without this, you can accidentally create db files in dynamo that you
would be unable to access from the loadable module.